### PR TITLE
Feat/reflection

### DIFF
--- a/reflection/reflection.go
+++ b/reflection/reflection.go
@@ -1,0 +1,57 @@
+package main
+
+import "reflect"
+
+type Person struct {
+	Name    string
+	Profile Profile
+}
+
+type Profile struct {
+	City string
+	Age  int
+}
+
+func walk(x interface{}, fn func(input string)) {
+	val := getValue(x)
+
+	walkValue := func(value reflect.Value) {
+		walk(value.Interface(), fn)
+	}
+
+	switch val.Kind() {
+	case reflect.String:
+		fn(val.String())
+	case reflect.Struct:
+		for i := 0; i < val.NumField(); i++ {
+			walkValue(val.Field(i))
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < val.Len(); i++ {
+			walkValue(val.Index(i))
+		}
+	case reflect.Map:
+		for _, key := range val.MapKeys() {
+			walkValue(val.MapIndex(key))
+		}
+	case reflect.Chan:
+		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
+			walkValue(v)
+		}
+	case reflect.Func:
+		valFnResult := val.Call(nil)
+		for _, res := range valFnResult {
+			walkValue(res)
+		}
+	}
+}
+
+func getValue(x interface{}) reflect.Value {
+	val := reflect.ValueOf(x)
+
+	if val.Kind() == reflect.Pointer {
+		val = val.Elem()
+	}
+
+	return val
+}

--- a/reflection/reflection_test.go
+++ b/reflection/reflection_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWalk(t *testing.T) {
+	cases := []struct {
+		Name          string
+		Input         interface{}
+		ExpectedCalls []string
+	}{
+		{
+			"struct with one string field",
+			struct {
+				Name string
+			}{"Clebson"},
+			[]string{"Clebson"},
+		},
+		{
+			"struct with two string fields",
+			struct {
+				Name string
+				City string
+			}{"Clebson", "SP"},
+			[]string{"Clebson", "SP"},
+		},
+		{
+			"struct with non string field",
+			struct {
+				Name string
+				Age  int
+			}{"Clebson", 35},
+			[]string{"Clebson"},
+		},
+		{
+			"nested fields",
+			Person{
+				"Clebson",
+				Profile{"SP", 35},
+			},
+			[]string{"Clebson", "SP"},
+		},
+		{
+			"pointers to things",
+			&Person{
+				"Clebson",
+				Profile{"SP", 35},
+			},
+			[]string{"Clebson", "SP"},
+		},
+		{
+			"slices",
+			[]Profile{
+				{"SP", 23},
+				{"BSB", 19},
+			},
+			[]string{"SP", "BSB"},
+		},
+		{
+			"arrays",
+			[2]Profile{
+				{"SP", 23},
+				{"BSB", 19},
+			},
+			[]string{"SP", "BSB"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			var got []string
+
+			walk(test.Input, func(input string) {
+				got = append(got, input)
+			})
+
+			if !reflect.DeepEqual(got, test.ExpectedCalls) {
+				t.Errorf("got %q, want %q", got, test.ExpectedCalls)
+			}
+		})
+	}
+
+	t.Run("with maps", func(t *testing.T) {
+		aMap := map[string]string{
+			"Cow":   "Moo",
+			"Sheep": "Baa",
+		}
+
+		var got []string
+		walk(aMap, func(input string) {
+			got = append(got, input)
+		})
+
+		assertContains(t, got, "Moo")
+		assertContains(t, got, "Baa")
+	})
+
+	t.Run("with channels", func(t *testing.T) {
+		aChannel := make(chan Profile)
+
+		go func() {
+			aChannel <- Profile{"SP", 23}
+			aChannel <- Profile{"BSB", 19}
+			close(aChannel)
+		}()
+
+		var got []string
+		want := []string{"SP", "BSB"}
+
+		walk(aChannel, func(input string) {
+			got = append(got, input)
+		})
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("with function", func(t *testing.T) {
+		aFunction := func() (Profile, Profile) {
+			return Profile{"SP", 23}, Profile{"BSB", 19}
+		}
+
+		var got []string
+		want := []string{"SP", "BSB"}
+
+		walk(aFunction, func(input string) {
+			got = append(got, input)
+		})
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func assertContains(t testing.TB, haystack []string, needle string) {
+	t.Helper()
+	contains := false
+	for _, x := range haystack {
+		if x == needle {
+			contains = true
+		}
+	}
+
+	if !contains {
+		t.Errorf("expected %v to contain %q but it didn't", haystack, needle)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new functionality to recursively walk through various data structures and apply a given function to each string element found. It includes the implementation of the `walk` function and its associated test cases.

### Implementation of `walk` function:

* [`reflection/reflection.go`](diffhunk://#diff-3d2f61e6430a108534c1e7a8ddfb2ebcca5afb2e55d46f3f037b53078cb4281cR1-R57): Added the `walk` function that recursively traverses different kinds of data structures (structs, slices, arrays, maps, channels, and functions) and applies a provided function to each string element found.

### Test cases for `walk` function:

* [`reflection/reflection_test.go`](diffhunk://#diff-903db29f498f0d90607a3f56a720eec5de6a4488b48818c3e712bd69b0007076R1-R151): Added comprehensive test cases for the `walk` function to ensure it correctly handles various data structures, including structs, slices, arrays, maps, channels, and functions.